### PR TITLE
gem 'pry'を導入しbinding.pryを使用できるようにしました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -128,6 +129,9 @@ GEM
     nokogiri (1.15.1-x86_64-darwin)
       racc (~> 1.4)
     pg (1.5.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -215,6 +219,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
+  pry
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   selenium-webdriver


### PR DESCRIPTION
目的：
開発の際に「binding.pry」を使用してデバックをする必要があるために導入しました。

内容：
gemfileに「gem 'pry'」と記述し、bundle installをしました。