### PR TITLE
ポスグレに接続できるようにするためにconfig/database.ymlファイルのパスワードを設定しました。

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,6 +25,7 @@ development:
   <<: *default
   database: furima_app2_development
 
+
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
@@ -32,7 +33,7 @@ development:
   #username: furima_app2
 
   # The password associated with the postgres role (username).
-  #password:
+  password:kyoya
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have


### PR DESCRIPTION
目的：
devise設定中に「We could not find your database」と出てしまったため、これを解決するためにconfig/database.ymlファイルのパスワードを設定したいです。

内容：
The password associated with the postgres role (username).
  password:
のパスワード欄にkyoyaと設定しました。