### PR TITLE
“config/database.ymlファイルで構文エラーが出たため修正しました。”

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -33,7 +33,7 @@ development:
   #username: furima_app2
 
   # The password associated with the postgres role (username).
-  password:kyoya
+  password: kyoya
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have


### PR DESCRIPTION
目的：
config/database.ymlファイルで構文エラーが出たため修正しました。

内容：
おそらく「password:kyoya」のようの「：」とパスワードの間にスペースがなかったことが原因と考えられるため、「password: kyoya」に修正をしました。