### PR TITLE
config/initializers/devise.rbにある「config.authentication_keys=[:email]」を「:name」に変更する

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  # config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the


### PR DESCRIPTION
目的：
ログイン時にnameとpasswordを設定する仕様にしたいため、デフォルトで設定していた「config.authentication_keys = [:email]」を「:name」に変更しました。

内容：
config/initializers/devise.rbにある「config.authentication_keys = [:email]」を「:name」に変更する