### PR TITLE
Deviseのパスワード忘れページを作成しました。

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,15 +1,15 @@
-<h2>Forgot your password?</h2>
+<h2>パスワードを忘れた方はこちら</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワードリセットの案内メールを送信" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
目的：
ログイン画面にDeviseのパスワード忘れページの設定が必要なため、そのviewを作成しました。

内容：
deviseのデフォルトにあるviewを日本語に修正しました。

<img width="508" alt="スクリーンショット 2023-05-21 15 43 24" src="https://github.com/shinke1171718/furima_app2/assets/110751171/efed8efb-4cb6-4348-b7f1-41b2b2c04c3e">
