### PR TITLE
itemモデルにカラムを追加しました。

### DIFF
--- a/db/migrate/20230521095654_create_items.rb
+++ b/db/migrate/20230521095654_create_items.rb
@@ -1,7 +1,11 @@
 class CreateItems < ActiveRecord::Migration[7.0]
   def change
     create_table :items do |t|
-
+      t.string :name,                 nill: false, default: ""
+      t.text :explanation,            nill: false, default: ""
+      t.integer :price,               nill: false, default: ""
+      t.string :seller_id,            nill: false, default: ""
+      t.string :buyer_id
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_21_012956) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_21_095654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.string "name", default: ""
+    t.text "explanation", default: ""
+    t.integer "price"
+    t.string "seller_id", default: ""
+    t.string "buyer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", default: ""


### PR DESCRIPTION
目的：
itemモデルに追加したカラムはユーザーが購入時に最低限求めている情報を商品ごとに付け加えることで、購入意欲を高めることに繋がるため追加しました。

内容：
５つのカラムを追加して「rails db:migrate」を行いました。
※追加したうちの「seller_id」と「buyer_id」については購入時に「seller_id」では出品者の情報（user_id）が入ります。
「buyer_id」については購入時に「誰が購入したかの情報（購入者のuser_id）」が入ります。また「buyer_id」については購入時にデータが入るため、「nill: false」という制約はもうけていません。合わせて「buyer_id」にデータが入ることで購入済みになったかどうかを判断できるようにしたいと考えています。