### PR TITLE
Orderモデルにuser_idとitem_idの外部キーを追加しました。

### DIFF
--- a/db/migrate/20230521154224_create_orders.rb
+++ b/db/migrate/20230521154224_create_orders.rb
@@ -1,7 +1,8 @@
 class CreateOrders < ActiveRecord::Migration[7.0]
   def change
     create_table :orders do |t|
-
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_21_095654) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_21_154224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_095654) do
     t.string "buyer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,4 +49,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_095654) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end


### PR DESCRIPTION
目的：
Orderモデルにuser_idとitem_idの外部キーを追加することで、ユーザーと商品の関連付けを実現します。これにより、ユーザーごとの注文履歴を追跡し、各注文に関連する商品情報を簡単に取得できるようになります。

内容：
Orderモデルにuser_idとitem_idの外部キーを追加しました。
