### PR TITLE
ユーザー登録のためにRegistrationsControllerをオーバーライドしました。

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,11 @@
+class RegistrationsController < Devise::RegistrationsController
+  private
+
+  def sign_up_params
+    params.require(:user).permit(:name, :postal_code, :address1, :address2, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.require(:user).permit(:name, :postal_code, :address1, :address2, :email, :password, :password_confirmation, :current_password)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
-
+  devise_for :users, controllers: { registrations: 'registrations' }
   resources :item do
     member do
       get :checkout


### PR DESCRIPTION
目的：
ユーザー登録時にカスタムパラメーターを許可するためにRegistrationsControllerを変更しました。

内容：
sign_up_paramsメソッドとaccount_update_paramsメソッドを修正して、:name、:postal_code、:address1、:address2のパラメーターを許可するようにしました。この変更により、ユーザーは登録プロセス中に追加情報を提供することができます。