### PR TITLE
ルートパスをitems#indexに設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root to: 'items#index'
   devise_for :users, controllers: { registrations: 'registrations' }
   resources :item do
     member do


### PR DESCRIPTION
内容：
アプリケーションのトップページが最初にユーザーが求めている情報にすることで購入意欲の増進になるため、アイテム一覧ページをトップページにしたいと考えています。


内容：
config/routes.rb のルートパスを 'items#index' に変更しました。
これにより、アプリケーションのトップページがアイテム一覧ページとなります。