### PR TITLE
UserモデルとOrderモデルの間にhas_manyの関連付けを追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,5 @@
 class Item < ApplicationRecord
   before_action :authenticate_user!
+  has_many :orders
+  has_many :users, through: :orders
 end


### PR DESCRIPTION
目的：
UserモデルとOrderモデルの関連付けを設定し、ユーザーが注文履歴を取得できるようにするために設定しました。

内容：
UserモデルとOrderモデルの間にhas_manyの関連付けを追加