### PR TITLE
itemモデルとOrderモデルの間にhas_manyの関連付けを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :orders
+  has_many :items, through: :orders
 end


### PR DESCRIPTION
目的：
ItemモデルとOrderモデルの関連付けを設定し、ユーザーが注文履歴を取得できるようにするために設定しました。

内容：
ItemモデルとOrderモデルの間にhas_manyの関連付けを追加