### PR TITLE
itemモデルに画像との関連付けを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :orders
   has_many :items, through: :orders
+  has_many :image
 end


### PR DESCRIPTION
目的：
temモデルにhas_many :imagesを追加し、複数の画像と関連付けを設定しました。

内容：
Itemモデルにhas_many :imagesを追加し、複数の画像と関連付けを設定しました。
これにより、アイテムの画像を関連付けて管理できるようになりました。