### PR TITLE
Userモデルに画像との関連付けを追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,5 @@ class Item < ApplicationRecord
   before_action :authenticate_user!
   has_many :orders
   has_many :users, through: :orders
+  has_many :image
 end


### PR DESCRIPTION
目的：
itemモデルに画像との関連付けを追加

内容：
Userモデルにhas_many :userを追加し、画像と関連付けを設定しました。
これにより、アイテムの画像を関連付けて管理できるようになりました。