### PR TITLE
ImageUploaderファイルに異なるバージョンの画像処理を追加

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,55 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  Create different versions of your uploaded files:
+  version :thumb do
+    process resize_to_fit: [50, 50]
+  end
+
+  version :large do
+    process resize_to_fit: [800, 800]
+  end
+
+  version :small do
+    process resize_to_fill: [200, 200]
+  end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end


### PR DESCRIPTION
目的：
画像アップロード時に異なるバージョンの処理を行い、複数の画像サイズを管理できるようにしました。
これはitem#indexとitem#showで必要となります。

内容：
largeバージョン: 800x800ピクセルにリサイズする処理を追加
smallバージョン: 200x200ピクセルにリサイズして埋める処理を追加
これにより、アップロードされた画像は異なるサイズで保存され、表示時に適切なサイズで表示されるようになります。