### PR TITLE
OrderモデルにUserとItemへの所属関係を設定

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,4 @@
 class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
 end


### PR DESCRIPTION
目的：
OrderモデルにUserとItemへの所属関係を設定するために記述

内容：
Userモデルとの関連付け: belongs_to :user
Itemモデルとの関連付け: belongs_to :item
これにより、OrderモデルはUserとItemとの関連付けが可能となります。