### PR TITLE
“不要な認証フィルターを削除”

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,4 @@
 class Item < ApplicationRecord
-  before_action :authenticate_user!
   has_many :orders
   has_many :users, through: :orders
   has_many :image


### PR DESCRIPTION
目的：
アプリケーションの認証フィルターを見直し、不要なフィルターを削除する

内容：
before_action :authenticate_user!を削除し、不要な認証チェックを除去する