### PR TITLE
“マイページから「購入済み商品一覧」と「出品商品一覧」が確認できるようにしました。”

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -2,4 +2,15 @@ class MypagesController < ApplicationController
   def show
     @current_user = current_user
   end
+
+  #購入済み商品一覧を表示する機能
+  def purchased_items
+    @purchase_items = Item.where(buyer_id: current_user.id)
+  end
+
+  #出品商品一覧を表示する機能
+  def listed_items
+    @listed_items = Item.where(seller_id: current_user.id)
+  end
+
 end

--- a/app/models/mypage.rb
+++ b/app/models/mypage.rb
@@ -1,3 +1,4 @@
 class Mypage < ApplicationRecord
   belongs_to :user
+  has_one_attached :image
 end

--- a/app/views/mypages/listed_items.html.erb
+++ b/app/views/mypages/listed_items.html.erb
@@ -1,0 +1,16 @@
+<h1>出品商品一覧</h1>
+<button><%= link_to "戻る", mypage_path %></button>
+
+<% if @listed_items.present? %>
+  <% @listed_items.each do |item| %>
+    <% if item.image.attached? %>
+      <%= link_to item_path(item) do %>
+        <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
+      <% end %>
+    <% else %>
+      <p>No image</p>
+    <% end %>
+  <% end %>
+<% else %>
+  <p>出品商品はありません</p>
+<% end %>

--- a/app/views/mypages/purchased_items.html.erb
+++ b/app/views/mypages/purchased_items.html.erb
@@ -1,0 +1,16 @@
+<h1>購入済み商品一覧</h1>
+<button><%= link_to "戻る", mypage_path %></button>
+
+<% if @purchase_items.present? %>
+  <% @purchase_items.each do |item| %>
+    <% if item.image.attached? %>
+      <%= link_to item_path(item) do %>
+        <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
+      <% end %>
+    <% else %>
+      <p>No image</p>
+    <% end %>
+  <% end %>
+<% else %>
+  <p>購入済み商品はありません</p>
+<% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,2 +1,22 @@
 <h1>マイページ</h1>
-<a class="nav-link"><%= link_to "ログアウト", destroy_user_session_path %></a>
+<button><%= link_to "戻る", root_path %></button>
+<nav class="mypage_navbar">
+  <ul class="mypage_navbar-nav">
+    <li class="mypage_nav-item">
+      <a class="nav-link"><%= link_to "ログアウト", destroy_user_session_path %></a>
+    </li>
+    <li class="mypage_nav-item">
+      <a class="nav-link"><%= link_to "購入済み商品一覧", purchased_items_mypage_path %></a>
+    </li>
+    <li class="mypage_nav-item">
+      <a class="nav-link"><%= link_to "出品商品一覧", listed_items_mypage_path %></a>
+    </li>
+    <li class="mypage_nav-item">
+      <a class="nav-link"><%= link_to "サブ住所登録" %></a>
+    </li>
+    <li class="mypage_nav-item">
+      <a class="nav-link"><%= link_to "ユーザー情報編集" %></a>
+    </li>
+  </ul>
+</nav>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,10 @@ Rails.application.routes.draw do
     end
   end
   resources :messages
-  resources :mypages
+  resources :mypages do
+    member do
+      get :purchased_items
+      get :listed_items
+    end
+  end
 end


### PR DESCRIPTION
目的：
マイページに「購入済み商品一覧」と「出品商品一覧」の表示機能を追加することで、ユーザーが自身の購入履歴と出品履歴を簡単に確認できるようにします。

内容：
・「購入済み商品一覧」の表示: ユーザーが購入した商品の一覧をマイページで確認できます。購入商品の商品名と画像が一覧として表示されます。
・「出品商品一覧」の表示: ユーザーが出品した商品の一覧をマイページで確認できます。出品商品の商品名と画像が一覧として表示されます。