### PR TITLE
マイページよりサブ住所の登録ができるよう設定しました。

### DIFF
--- a/app/controllers/secondaddresses_controller.rb
+++ b/app/controllers/secondaddresses_controller.rb
@@ -1,0 +1,46 @@
+class SecondaddressesController < ApplicationController
+
+  def edit_or_new
+    #ログインユーザーでサブ住所が登録してあるか確認（あればeditアクションへ、なければnewアクションへ）
+    if current_user.secondaddress.present?
+      redirect_to edit_secondaddress_path(current_user.secondaddress)
+    else
+      redirect_to new_secondaddress_path
+    end
+  end
+
+  def new
+    @secondaddress = Secondaddress.new
+  end
+
+  def create
+    @secondaddress = Secondaddress.new(secondaddress_params)
+    @secondaddress.user = current_user
+    if @secondaddress.save
+      redirect_to edit_secondaddress_path(@secondaddress), notice: "サブ住所を登録しました。"
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @secondaddress = current_user.secondaddress
+  end
+
+  def update
+    @secondaddress = current_user.secondaddress
+
+    if @secondaddress.update(secondaddress_params)
+      redirect_to edit_secondaddress_path(@secondaddress), notice: "サブ住所を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def secondaddress_params
+    params.require(:secondaddress).permit(:second_postal_code, :second_address1, :second_address2)
+  end
+
+end

--- a/app/helpers/secondaddresses_helper.rb
+++ b/app/helpers/secondaddresses_helper.rb
@@ -1,0 +1,2 @@
+module SecondaddressesHelper
+end

--- a/app/models/secondaddress.rb
+++ b/app/models/secondaddress.rb
@@ -1,0 +1,3 @@
+class Secondaddress < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
   has_secure_password
   validates :email, uniqueness: true
   has_one :mypage
+  has_one :secondaddress
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -12,7 +12,7 @@
       <a class="nav-link"><%= link_to "出品商品一覧", listed_items_mypage_path %></a>
     </li>
     <li class="mypage_nav-item">
-      <a class="nav-link"><%= link_to "サブ住所登録" %></a>
+      <a class="nav-link"><%= link_to "サブ住所編集", edit_or_new_secondaddress_path %></a>
     </li>
     <li class="mypage_nav-item">
       <a class="nav-link"><%= link_to "ユーザー情報編集" %></a>

--- a/app/views/secondaddresses/edit.html.erb
+++ b/app/views/secondaddresses/edit.html.erb
@@ -1,0 +1,28 @@
+<h1>サブ住所更新</h1>
+
+<button><%= link_to "戻る", root_path %></button>
+
+<% if flash[:notice] %>
+  <div class="flash notice">
+    <%= flash[:notice] %>
+  </div>
+<% end %>
+
+<%= form_with model: @secondaddress, url: secondaddress_path(@secondaddress), method: :patch do |f| %>
+  <div class="field">
+    <%= f.label :郵便番号（ハイフンは除いて） %><br />
+    <%= f.text_field :second_postal_code %>
+  </div>
+
+  <div class="field">
+    <%= f.label :市区町村まで入力 %><br />
+    <%= f.text_field :second_address1 %>
+  </div>
+
+  <div class="field">
+    <%= f.label :番地（建物名・部屋番号） %><br />
+    <%= f.text_field :second_address2 %>
+  </div>
+
+  <%= f.submit "更新" %>
+<% end %>

--- a/app/views/secondaddresses/new.html.erb
+++ b/app/views/secondaddresses/new.html.erb
@@ -1,0 +1,22 @@
+<h1>サブ住所の新規登録</h1>
+
+<button><%= link_to "戻る", root_path %></button>
+
+<%= form_with model: @secondaddress, url: secondaddresses_path do |f| %>
+  <div class="field">
+    <%= f.label :郵便番号（ハイフンは除いて） %><br />
+    <%= f.text_field :second_postal_code %>
+  </div>
+
+  <div class="field">
+    <%= f.label :市区町村まで入力 %><br />
+    <%= f.text_field :second_address1 %>
+  </div>
+
+  <div class="field">
+    <%= f.label :番地（建物名・部屋番号） %><br />
+    <%= f.text_field :second_address2 %>
+  </div>
+
+  <%= f.submit "登録" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,7 @@ Rails.application.routes.draw do
       get :listed_items
     end
   end
+
+  get 'secondaddress/edit_or_new', to: 'secondaddresses#edit_or_new', as: 'edit_or_new_secondaddress'
+  resources :secondaddresses
 end

--- a/db/migrate/20230521012956_devise_create_users.rb
+++ b/db/migrate/20230521012956_devise_create_users.rb
@@ -10,6 +10,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.0]
       t.string :address1,           null: false, default: ""
       t.string :address2,           null: false, default: ""
       t.string :password_digest,    null: false, default: ""
+      t.references :secondaddress
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20230613100545_create_secondaddresses.rb
+++ b/db/migrate/20230613100545_create_secondaddresses.rb
@@ -1,0 +1,11 @@
+class CreateSecondaddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :secondaddresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :second_postal_code,            nill: false, default: ""
+      t.string :second_address1,            nill: false, default: ""
+      t.string :second_address2,            nill: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_011406) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_100545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,6 +97,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_011406) do
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
+  create_table "secondaddresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "second_postal_code", default: ""
+    t.string "second_address1", default: ""
+    t.string "second_address2", default: ""
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_secondaddresses_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
@@ -104,6 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_011406) do
     t.string "address1", default: "", null: false
     t.string "address2", default: "", null: false
     t.string "password_digest", default: "", null: false
+    t.bigint "secondaddress_id"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -111,6 +122,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_011406) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["secondaddress_id"], name: "index_users_on_secondaddress_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -123,4 +135,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_011406) do
   add_foreign_key "mypages", "users"
   add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"
+  add_foreign_key "secondaddresses", "users"
 end

--- a/test/controllers/secondaddresses_controller_test.rb
+++ b/test/controllers/secondaddresses_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SecondaddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/secondaddresses.yml
+++ b/test/fixtures/secondaddresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/secondaddress_test.rb
+++ b/test/models/secondaddress_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SecondaddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的
マイページにサブ住所の登録機能を追加したことで、ユーザーがマイページからサブ住所を登録できるようにしました。

内容
・マイページにサブ住所の登録フォームを追加しました。
・サブ住所をデータベースに保存するための必要なモデルとマイグレーションを作成しました。
・サブ住所の作成、編集に対応するコントローラーとビューを作成しました。
・ユーザーとサブ住所の関連付けを行い、ユーザーが登録したサブ住所を取得できるようにしました。
