### PR TITLE
“商品ページより配送先の設定ができるようになりました。”

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,30 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     @chat = Chat.find_by(item_id: @item.id)
     @current_user = current_user
+
+    # 住所とサブ住所のデータを取得し、インスタンスに格納する
+    if current_user.present?
+      @address = {
+        postal_code: current_user.postal_code,
+        address1: current_user.address1,
+        address2: current_user.address2
+      }
+
+      # テキスト化して結合
+      @address[:text] = "#{@address[:postal_code]}, #{@address[:address1]}, #{@address[:address2]}"
+    end
+
+    if current_user.secondaddress.present?
+      @second_address = {
+        second_postal_code: current_user.secondaddress.second_postal_code,
+        second_address1: current_user.secondaddress.second_address1,
+        second_address2: current_user.secondaddress.second_address2
+      }
+
+      # テキスト化して結合
+      @second_address[:text] = "#{@second_address[:second_postal_code]}, #{@second_address[:second_address1]}, #{@second_address[:second_address2]}"
+    end
+
   end
 
   def new
@@ -40,6 +64,10 @@ class ItemsController < ApplicationController
   def cheackout
     @item = Item.find(params[:item_id])
     @item.update(buyer_id: current_user.id)
+
+    #洗濯した住所のデータを格納する。
+    selected_address = params[:selected_address]
+    @item.update(address: selected_address)
   end
 
   private

--- a/app/views/items/cheackout.html.erb
+++ b/app/views/items/cheackout.html.erb
@@ -18,11 +18,14 @@
     <p>金額：<%= @item.price %>円</P>
   </div>
 
+  <div class="field">
+    <p>配送先：<%= @item.address %>への配送をします。</P>
+  </div>
+
 <% end %>
-</div>
 
 <%= form_tag(root_path, method: :get) do %>
-  <%= hidden_field_tag 'item[buyer_id]', current_user.id %>
+  <%= hidden_field_tag 'item[buyer_id]', @current_user.id %>
   <%= submit_tag '購入する（最終確認です。キャンセルは不可です。）' %>
 <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,10 @@
 <h1>商品の詳細画面になります。</h1>
-<button><%= link_to "戻る", root_path %></button>
+
+<% if @item.buyer_id.present? %>
+  <button><%= link_to "戻る", purchased_items_mypage_path %></button>
+<% else %>
+  <button><%= link_to "戻る", root_path %></button>
+<% end %>
 
 <%= form_tag(item_cheackout_path, method: :get) do %>
   <%= hidden_field_tag :item_id, @item.id %>
@@ -21,33 +26,55 @@
 
 <% end %>
 
-<div class="posts">
-  <% if @chat.messages.blank? %>
-    <p>コメントはありません</p>
-  <% else %>
-    <% @chat.messages.each do |message| %>
-      <p><%= message.user.name %>: <%= message.comment %></p>
+<% if @item.buyer_id.present? %>
+  <p>購入済み商品です。</p>
+<% else %>
+  <h3>チャット</h3>
+  <div class="posts">
+    <% if @chat.messages.blank? %>
+      <p>コメントはありません</p>
+    <% else %>
+      <% @chat.messages.each do |message| %>
+        <p><%= message.user.name %>: <%= message.comment %></p>
+      <% end %>
     <% end %>
+  </div>
+
+
+
+  <div class="posts">
+    <%= form_with(url: messages_path, method: :post) do |form| %>
+
+      <%= form.hidden_field :chat_id, value: @chat.id %>
+      <%= form.hidden_field :user_id, value: @current_user.id %>
+
+      <%= form.text_field :comment %>
+      <%= form.submit "送信" %>
+    <% end %>
+  </div>
+
+  <%= form_tag(item_cheackout_path(@item), method: :get) do %>
+    <%= hidden_field_tag :item_id, @item.id %>
+
+    <% if @address.present? %>
+      <h3>住所</h3>
+      <% address_text = "#{@address[:postal_code]} #{@address[:address1]} #{@address[:address2]}" %>
+      <p><%= address_text %></p>
+      <%= radio_button_tag 'selected_address', address_text %>
+      この住所を選択する
+    <% end %>
+
+    <% if @second_address.present? %>
+      <h3>サブ住所</h3>
+      <% second_address_text = "#{@second_address[:second_postal_code]} #{@second_address[:second_address1]} #{@second_address[:second_address2]}" %>
+      <p><%= second_address_text %></p>
+      <%= radio_button_tag 'selected_address', second_address_text %>
+      このサブ住所を選択する
+    <% end %>
+
+    <br /><br />
+    <%= submit_tag '購入する' %>
   <% end %>
-</div>
-
-
-
-<div class="posts">
-  <%= form_with(url: messages_path, method: :post) do |form| %>
-
-    <%= form.hidden_field :chat_id, value: @chat.id %>
-    <%= form.hidden_field :user_id, value: @current_user.id %>
-
-    <%= form.text_field :comment %>
-    <%= form.submit "送信" %>
-  <% end %>
-</div>
-
-<%= form_tag(item_cheackout_path(@item), method: :get) do %>
-  <%= hidden_field_tag :item_id, @item.id %>
-  <%= submit_tag '購入する' %>
 <% end %>
-
 
 

--- a/db/migrate/20230521095654_create_items.rb
+++ b/db/migrate/20230521095654_create_items.rb
@@ -8,6 +8,7 @@ class CreateItems < ActiveRecord::Migration[7.0]
       t.text :image_meta_data,        null: false, default: ""
       t.string :seller_id,            null: false, default: ""
       t.string :buyer_id
+      t.text :address
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_100545) do
     t.text "image_meta_data", default: "", null: false
     t.string "seller_id", default: "", null: false
     t.string "buyer_id"
+    t.text "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
目的：
商品ページに配送先の設定機能を追加

内容：
・商品ページに「配送先の設定」セクションを追加しました。
・ユーザーは、「初期に設定した住所」「サブ住所」の候補から選択できるよにうになっています。