### PR TITLE
マイページのサブ住所の戻るボタンのリダイレクト先を修正しました。

### DIFF
--- a/app/views/secondaddresses/edit.html.erb
+++ b/app/views/secondaddresses/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>サブ住所更新</h1>
 
-<button><%= link_to "戻る", root_path %></button>
+<button><%= link_to "戻る", mypage_path %></button>
 
 <% if flash[:notice] %>
   <div class="flash notice">


### PR DESCRIPTION
目的
サブ住所の編集画面における「戻る」ボタンのリダイレクト先を、正しいマイページに変更しました。

内容
リダイレクト先を「root_path」から「mypage_path」へ変更しました。