### PR TITLE
マイページのサブ住所の戻るボタンのリダイレクト先を修正（new.html.erb）

### DIFF
--- a/app/views/secondaddresses/new.html.erb
+++ b/app/views/secondaddresses/new.html.erb
@@ -1,6 +1,6 @@
 <h1>サブ住所の新規登録</h1>
 
-<button><%= link_to "戻る", root_path %></button>
+<button><%= link_to "戻る", mypage_path %></button>
 
 <%= form_with model: @secondaddress, url: secondaddresses_path do |f| %>
   <div class="field">


### PR DESCRIPTION
目的
サブ住所の編集画面におけるnew.html.erbに記述してある「戻る」ボタンのリダイレクト先を、正しいマイページに変更しました。

内容
リダイレクト先を「root_path」から「mypage_path」へ変更しました。