### PR TITLE
サブ住所設定のページからマイページへの戻るボタン修正＋Registrationscontrollerの記述修正

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -50,7 +50,6 @@ class RegistrationsController < ApplicationController
       @user.update(user_params_without_password)
       flash[:notice] = "ユーザー情報を更新しました。（パスワード未更新：パスワードを設定された場合には入力漏れがないか確認してください。）"
       redirect_to edit_user_registration_path
-      end
     end
   end
 

--- a/app/controllers/secondaddresses_controller.rb
+++ b/app/controllers/secondaddresses_controller.rb
@@ -11,9 +11,11 @@ class SecondaddressesController < ApplicationController
 
   def new
     @secondaddress = Secondaddress.new
+    @user =current_user
   end
 
   def create
+    @user =current_user
     @secondaddress = Secondaddress.new(secondaddress_params)
     @secondaddress.user = current_user
     if @secondaddress.save

--- a/app/views/secondaddresses/edit.html.erb
+++ b/app/views/secondaddresses/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>サブ住所更新</h1>
 
-<button><%= link_to "戻る", mypage_path %></button>
+<button><%= link_to "戻る", mypage_path(@user) %></button>
 
 <% if flash[:notice] %>
   <div class="flash notice">

--- a/app/views/secondaddresses/new.html.erb
+++ b/app/views/secondaddresses/new.html.erb
@@ -1,6 +1,6 @@
 <h1>サブ住所の新規登録</h1>
 
-<button><%= link_to "戻る", mypage_path %></button>
+<button><%= link_to "戻る", mypage_path(@user) %></button>
 
 <%= form_with model: @secondaddress, url: secondaddresses_path do |f| %>
   <div class="field">


### PR DESCRIPTION
目的
このプルリクエストの目的は、サブ住所設定ページからマイページへの戻るボタンの修正と、RegistrationsControllerの記述の修正を行うことです。修正により、ユーザーがサブ住所設定ページから正しくマイページに戻ることができるようになります。また、RegistrationsControllerの記述に無駄な記述がありその修正を行いました。

内容
サブ住所設定ページ（secondaddresses#new）のビューファイル（new.html.erb）において、戻るボタンのリンク先を修正しました。修正前はmypage_pathを呼び出していましたが、必要なパラメータが欠けているためエラーが発生していました。