### PR TITLE
フラッシュメッセージをパーシャルへ変更しました。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -55,6 +55,7 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    @current_user = current_user
   end
 
   def update

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,10 +1,6 @@
 <h1>出品商品の編集</h1>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <button><%= link_to '戻る', listed_items_mypage_path(id: @item.id) %></button>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -10,11 +10,7 @@
 
 <h1>商品一覧</h1>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <% @items.each do |item| %>
   <% if item.image.attached? %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,10 +1,6 @@
 <h1>出品したい商品の情報を入力してください。</h1>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <button><%= link_to "戻る", request.referer || root_path %></button>
 

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,11 +1,7 @@
 <h1>ユーザー情報編集</h1>
 <button><%= link_to "戻る", mypage_path(@user) %></button>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <%= form_with model: @user, url: update_user_registration_path(@current_user_edit), method: :patch do |f| %>
 

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -2,11 +2,7 @@
 
 <%= render 'shared/error_messages', user: @user %>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
 	<div class="field">

--- a/app/views/secondaddresses/edit.html.erb
+++ b/app/views/secondaddresses/edit.html.erb
@@ -1,12 +1,8 @@
 <h1>サブ住所更新</h1>
 
-<button><%= link_to "戻る", mypage_path(@user) %></button>
+<button><%= link_to "戻る", mypage_path(@current_user.id) %></button>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <%= form_with model: @secondaddress, url: secondaddress_path(@secondaddress), method: :patch do |f| %>
   <div class="field">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,10 +1,6 @@
 <h1>ログイン画面</h1>
 
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>
+<%= render 'shared/flash_notice' %>
 
 <%= form_with url: user_session_path, local: true, method: :post do |f| %>
 	<div class="field">

--- a/app/views/shared/_flash_notice.html.erb
+++ b/app/views/shared/_flash_notice.html.erb
@@ -1,0 +1,5 @@
+<% if flash[:notice] %>
+  <div class="flash notice">
+    <%= flash[:notice] %>
+  </div>
+<% end %>


### PR DESCRIPTION
目的
フラッシュメッセージの表示方法を改善が目的です。現在、フラッシュメッセージはビューの各ページごとに重複して記述されており、メンテナンスや修正が煩雑です。そこで、フラッシュメッセージをパーシャルに変更することで、コードの重複を減らし、一貫性のあるメッセージ表示を実現します。

内容
・_flash_notice.html.erbという名前のパーシャルファイルを作成しました。
・パーシャルファイル内にフラッシュメッセージの表示コードを移動しました。
・各ビューファイルからパーシャルを呼び出すように修正しました。
・これにより、フラッシュメッセージのコードが重複せず、メンテナンスが容易になりました。