### PR TITLE
商品画像を表示コードをパーシャルへ変更しました。

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -13,13 +13,7 @@
 <%= render 'shared/flash_notice' %>
 
 <% @items.each do |item| %>
-  <% if item.image.attached? %>
-    <%= link_to item_path(item) do %>
-      <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
-    <% end %>
-  <% else %>
-    <p>No image</p>
-  <% end %>
+  <%= render partial: 'shared/item_with_image_link', locals: { item: item } %>
 <% end %>
 
 <div class="button-container">

--- a/app/views/mypages/listed_items.html.erb
+++ b/app/views/mypages/listed_items.html.erb
@@ -3,13 +3,7 @@
 
 <% if @listed_items.present? %>
   <% @listed_items.each do |item| %>
-    <% if item.image.attached? %>
-      <%= link_to item_path(item) do %>
-        <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
-      <% end %>
-    <% else %>
-      <p>No image</p>
-    <% end %>
+    <%= render partial: 'shared/item_with_image_link', locals: { item: item } %>
   <% end %>
 <% else %>
   <p>出品商品はありません</p>

--- a/app/views/mypages/purchased_items.html.erb
+++ b/app/views/mypages/purchased_items.html.erb
@@ -3,13 +3,7 @@
 
 <% if @purchase_items.present? %>
   <% @purchase_items.each do |item| %>
-    <% if item.image.attached? %>
-      <%= link_to item_path(item) do %>
-        <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
-      <% end %>
-    <% else %>
-      <p>No image</p>
-    <% end %>
+    <%= render partial: 'shared/item_with_image_link', locals: { item: item } %>
   <% end %>
 <% else %>
   <p>購入済み商品はありません</p>

--- a/app/views/shared/_item_with_image_link.html.erb
+++ b/app/views/shared/_item_with_image_link.html.erb
@@ -1,0 +1,5 @@
+<% if item.image.attached? %>
+  <%= link_to item_path(item) do %>
+    <%= image_tag(item.image.variant(resize_to_limit: [200, 200])) %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
目的
商品画像の表示コードをパーシャル化し、重複を排除してコードの可読性とメンテナンス性を向上させるため。

内容
商品画像の表示コードをパーシャル化しました。